### PR TITLE
Make it possible to start multiple workers

### DIFF
--- a/src/modsec_nif_worker.erl
+++ b/src/modsec_nif_worker.erl
@@ -2,7 +2,7 @@
 -behaviour(gen_server).
 
 -export([start_link/1, start_link/2]).
--export([check_request/4, check_request/5, check_response/2, check_response/3]).
+-export([check_request/5, check_response/3]).
 
 %% gen_server
 -export([
@@ -25,10 +25,7 @@ start_link(ConfDirectoryPattern) ->
     NumWorkers = erlang:system_info(schedulers),
     start_link(ConfDirectoryPattern, NumWorkers).
 start_link(ConfDirectoryPattern, NumWorkers) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [ConfDirectoryPattern, NumWorkers], []).
-
-check_request(RequestMethod, RequestUri, RequestHeaders, RequestBody) ->
-    check_request(?MODULE, RequestMethod, RequestUri, RequestHeaders, RequestBody).
+    gen_server:start_link(?MODULE, [ConfDirectoryPattern, NumWorkers], []).
 
 check_request(NameOrPid, RequestMethod, RequestUri, RequestHeaders, RequestBody) ->
     %% RequestMethod and RequestUri must be 0 terminated
@@ -38,9 +35,6 @@ check_request(NameOrPid, RequestMethod, RequestUri, RequestHeaders, RequestBody)
             RequestBody},
         infinity
     ).
-
-check_response(ResponseHeaders, ResponseBody) ->
-    check_response(?MODULE, ResponseHeaders, ResponseBody).
 
 check_response(NameOrPid, ResponseHeaders, ResponseBody) ->
     gen_server:call(

--- a/test/modsec_nif_worker_tests.erl
+++ b/test/modsec_nif_worker_tests.erl
@@ -9,10 +9,11 @@ check_test_() ->
     ].
 
 check_request() ->
-    modsec_nif_worker:start_link(<<"./test/**/*.conf">>),
+    {ok, Pid} = modsec_nif_worker:start_link(<<"./test/**/*.conf">>),
     ?assertMatch(
         {ok, []},
         modsec_nif_worker:check_request(
+            Pid,
             <<"POST">>,
             <<"/foo/bar">>,
             [
@@ -28,6 +29,7 @@ check_request() ->
     ?assertMatch(
         {error, [_ | _]},
         modsec_nif_worker:check_request(
+            Pid,
             <<"POST">>,
             <<"/test/artists.php?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user">>,
             [
@@ -43,6 +45,7 @@ check_request() ->
     ?assertMatch(
         {error, [_ | _]},
         modsec_nif_worker:check_request(
+            Pid,
             <<"POST">>,
             <<"/foo/bar">>,
             [
@@ -57,14 +60,15 @@ check_request() ->
     ).
 
 check_response() ->
-    modsec_nif_worker:start_link(<<"./test/**/*.conf">>),
+    {ok, Pid} = modsec_nif_worker:start_link(<<"./test/**/*.conf">>),
     ?assertMatch(
         {ok, []},
-        modsec_nif_worker:check_response([{<<"foo">>, <<"bar">>}], <<"foobar">>)
+        modsec_nif_worker:check_response(Pid, [{<<"foo">>, <<"bar">>}], <<"foobar">>)
     ),
     ?assertMatch(
         {ok, []},
         modsec_nif_worker:check_response(
+            Pid,
             [{<<"Content-Type">>, <<"application/json">>}],
             <<"{\"foo\":\"artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user\"}">>
         )


### PR DESCRIPTION
This is achieved by not registering the worker process.